### PR TITLE
PR: Fixes for the engine crashing (+ Other QOL stuff)

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -137,7 +137,7 @@
 	<!--In case you want to use the ui package-->
 	<haxelib name="flixel-ui" />
 	<haxelib name="linc_luajit" if="LUA_ALLOWED"/>
-	<haxelib name="hxCodec" if="VIDEOS_ALLOWED"/>
+	<haxelib name="hxCodec" if="VIDEOS_ALLOWED" version="2.5.1"/> <!-- Specify the version so people can compile! -->
 	<haxelib name="faxe" if='switch'/>
 	<!--<haxelib name="polymod"/> -->
 	<haxelib name="discord_rpc" if="desktop"/>

--- a/setup/libraries.bat
+++ b/setup/libraries.bat
@@ -1,10 +1,12 @@
 REM This contains all required libraries for this project
-haxelib git hxcpp https://github.com/HaxeFoundation/hxcpp.git
 haxelib set hxCodec 2.5.1
 haxelib install flixel
 haxelib install flixel-addons
 haxelib install flixel-ui
+haxelib install lime
 haxelib install hscript
 haxelib install discord-rpc
 haxelib install linc_luajit
+haxelib git hxcpp https://github.com/HaxeFoundation/hxcpp.git
+haxelib run lime setup
 pause

--- a/setup/libraries.bat
+++ b/setup/libraries.bat
@@ -1,0 +1,10 @@
+REM This contains all required libraries for this project
+haxelib git hxcpp https://github.com/HaxeFoundation/hxcpp.git
+haxelib set hxCodec 2.5.1
+haxelib install flixel
+haxelib install flixel-addons
+haxelib install flixel-ui
+haxelib install hscript
+haxelib install discord-rpc
+haxelib install linc_luajit
+pause

--- a/source/ClientPrefs.hx
+++ b/source/ClientPrefs.hx
@@ -91,7 +91,7 @@ class ClientPrefs
 		'modchart' => true,
 		'pbs' => false,
 		'sd' => false,
-		'hd' => true,
+		'hd' => false, /// Bro. why was this defaulted to on?
 		'sn' => true
 	];
 

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -395,19 +395,39 @@ class FreeplayState extends MusicBeatState
 				FlxG.sound.music.volume = 0;
 				Paths.currentModDirectory = songs[curSelected].folder;
 				var poop:String = Highscore.formatSong(songs[curSelected].songName.toLowerCase(), curDifficulty);
-				PlayState.SONG = Song.loadFromJson(poop, songs[curSelected].songName.toLowerCase());
-				if (PlayState.SONG.needsVoices)
-					vocals = new FlxSound().loadEmbedded(Paths.voices(PlayState.SONG.song));
-				else
-					vocals = new FlxSound();
+				// The following fixes both missing vocals AND crashing due to missing chart. ShadowMario TO THIS DAY has not fixed the freeplay missing chart crash error.
+				try
+					{
+						PlayState.SONG = Song.loadFromJson(poop, songs[curSelected].songName.toLowerCase());
+						if (PlayState.SONG.needsVoices)
+						{
+							try
+							{
+								vocals = new FlxSound().loadEmbedded(Paths.voices(PlayState.SONG.song));
+							}
+							catch(e:Dynamic)
+							{
+								vocals = new FlxSound();
+							}
+						}
+						else
+						{
+							vocals = new FlxSound();
+						}
 
-				FlxG.sound.list.add(vocals);
-				FlxG.sound.playMusic(Paths.inst(PlayState.SONG.song), 0.7);
-				vocals.play();
-				vocals.persist = true;
-				vocals.looped = true;
-				vocals.volume = 0.7;
-				instPlaying = curSelected;
+						FlxG.sound.list.add(vocals);
+						FlxG.sound.playMusic(Paths.inst(PlayState.SONG.song), 0.7);
+						vocals.play();
+						vocals.persist = true;
+						vocals.looped = true;
+						vocals.volume = 0.7;
+						instPlaying = curSelected;
+					}
+					catch(e:Dynamic)
+					{
+						trace('Error loading/playing file! $e');
+						FlxG.sound.play(Paths.sound('cancelMenu'));
+					}
 				#end
 			}
 		}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2620,9 +2620,20 @@ class PlayState extends MusicBeatState
 		curSong = songData.song;
 
 		if (SONG.needsVoices)
-			vocals = new FlxSound().loadEmbedded(Paths.voices(PlayState.SONG.song));
+		{
+			try
+			{
+				vocals = new FlxSound().loadEmbedded(Paths.voices(PlayState.SONG.song));
+			}
+			catch(e:Dynamic)
+			{
+				vocals = new FlxSound();
+			}
+		}
 		else
+		{
 			vocals = new FlxSound();
+		}
 
 		vocals.pitch = playbackRate;
 		FlxG.sound.list.add(vocals);

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -1694,8 +1694,7 @@ class ChartingState extends MusicBeatState
 		}
 		catch(e:Dynamic)
 		{
-			//trace("Song doesn't have a voices file!");
-			_song.needsVoices = false; // For PlayState so it doesn't ALSO die.
+			vocals = null;
 		}
 		generateSong();
 		FlxG.sound.music.pause();

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -1633,7 +1633,7 @@ class ChartingState extends MusicBeatState
 		blockPressWhileTypingOnStepper.push(instVolume);
 
 		voicesVolume = new FlxUINumericStepper(instVolume.x + 100, instVolume.y, 0.1, 1, 0, 1, 1);
-		voicesVolume.value = vocals.volume;
+		voicesVolume.value = vocals != null ? vocals.volume : 1;
 		voicesVolume.name = 'voices_volume';
 		blockPressWhileTypingOnStepper.push(voicesVolume);
 
@@ -1682,12 +1682,20 @@ class ChartingState extends MusicBeatState
 			// vocals.stop();
 		}
 
-		var file:Dynamic = Paths.voices(currentSongName);
-		vocals = new FlxSound();
-		if (Std.isOfType(file, Sound) || OpenFlAssets.exists(file))
+		try
 		{
-			vocals.loadEmbedded(file);
-			FlxG.sound.list.add(vocals);
+			var file:Dynamic = Paths.voices(currentSongName);
+			vocals = new FlxSound();
+			if (Std.isOfType(file, Sound) || OpenFlAssets.exists(file))
+			{
+				vocals.loadEmbedded(file);
+				FlxG.sound.list.add(vocals);
+			}
+		}
+		catch(e:Dynamic)
+		{
+			//trace("Song doesn't have a voices file!");
+			_song.needsVoices = false; // For PlayState so it doesn't ALSO die.
 		}
 		generateSong();
 		FlxG.sound.music.pause();
@@ -1716,7 +1724,8 @@ class ChartingState extends MusicBeatState
 			curSec = 0;
 			updateGrid();
 			updateSectionUI();
-			vocals.play();
+			if (vocals != null)
+				vocals.play();
 		};
 	}
 
@@ -1798,7 +1807,9 @@ class ChartingState extends MusicBeatState
 			}
 			else if (wname == 'voices_volume')
 			{
-				vocals.volume = nums.value;
+				if (vocals != null)
+					vocals.volume = nums.value;
+					
 			}
 		}
 		else if (id == FlxUIInputText.CHANGE_EVENT && (sender is FlxUIInputText))
@@ -2403,7 +2414,8 @@ class ChartingState extends MusicBeatState
 			playbackSpeed = 3;
 
 		FlxG.sound.music.pitch = playbackSpeed;
-		vocals.pitch = playbackSpeed;
+		if (vocals != null)
+			vocals.pitch = playbackSpeed;
 
 		bpmTxt.text = Std.string(FlxMath.roundDecimal(Conductor.songPosition / 1000, 2))
 			+ " / "


### PR DESCRIPTION
Charting State and Freeplay State no longer crash due to missing vocals file (And PlayState has a failsafe)

Specify the hxCodec version in the project.xml file, so people don't have to search for the version that actually works in this repo

Add a batch file containing the required libraries

This is a crazy engine, and i wanted to help out with making it a bit easier to work with.

(Thus the from source issues from earlier)